### PR TITLE
Update easy-number-separator.js

### DIFF
--- a/easy-number-separator.js
+++ b/easy-number-separator.js
@@ -41,5 +41,6 @@ function easyNumberSeparator(config) {
         return false;
       }
     });
+    el.value = numberSeparator(el.value);
   });
 }


### PR DESCRIPTION
Added line 44. This will cause all the control on form to be formatted when this plugin is initialized.